### PR TITLE
Issue "can't cast empty string to a number value"

### DIFF
--- a/src/cfjasperreport/tag/cfjasperreport/cfc/jasperreport.cfc
+++ b/src/cfjasperreport/tag/cfjasperreport/cfc/jasperreport.cfc
@@ -415,7 +415,11 @@
 				<cfset stTmp = structNew()>
 				<cfloop list="#lcase(q.columnlist)#" index="col">
 					<cfif types[col] == "INTEGER">
-						<cfset stTmp["#col#"] = javaCast("int",q[col][currentRow]) />
+						<cfif len(trim(q[col][currentRow]))>
+							<cfset stTmp["#col#"] = javaCast("int",q[col][currentRow]) />
+						<cfelse>
+							<cfset stTmp["#col#"] = javaCast("null","") />
+						</cfif>
 					<cfelse>
 						<cfset stTmp["#col#"] = q[col][currentRow] />
 					</cfif>


### PR DESCRIPTION
I encountered this exception when running this code. My query contained a column with NULL value which caused the exception since it was trying to cast a null to integer.

<cfquery name="myQuery" datasource="#datasource#">
    select \* from myTable
</cfquery>

<jr:jasperreport jrxml="#datapath#/sample-001.jrxml" query="#myQuery#" xportfile="#workpath#/sample-001.pdf" exporttype="pdf"/>
